### PR TITLE
Trump suit in the second phase

### DIFF
--- a/visual/index_interactive.html
+++ b/visual/index_interactive.html
@@ -18,6 +18,7 @@
 			<button id="exchange">Trump Exchange</button>
 			<div id="scoreboard2">Player 2: <div id="p2_points">0 points</div></div>
 		</div>
+		<div id="trump"></div>
 		<script type="text/javascript" src="{{ url_for('static', filename='js/index_interactive.js') }}"></script>
 	</body>
 

--- a/visual/static/css/example.css
+++ b/visual/static/css/example.css
@@ -90,6 +90,15 @@ body {
 #topbar button:disabled{
   opacity:.2;
 }
+#trump {
+  display: none;
+  position: fixed;
+  top: 50%;
+  right: 100px;
+  color: white;
+  border: 1px solid;
+  padding: 10px;
+}
 .message {
   position: fixed;
   top: 2.5rem;

--- a/visual/static/js/index_interactive.js
+++ b/visual/static/js/index_interactive.js
@@ -260,6 +260,11 @@ function getCardStateArray(backEndState, perspective=false){
     var card_state = (perspective && backEndState.phase == 1) ? backEndState.deck.p1_perspective : backEndState.deck.card_state;
 
     var trick = backEndState.deck.trick;
+    
+    if (backEndState.phase == 2) {
+        $("#trump").show();
+        $("#trump").text("Trump suit: " + properTrumpSuitName(backEndState.deck.trump_suit));
+    }
 
     for(var i=0; i<2; i++){
         if(trick[i] != null){
@@ -267,6 +272,16 @@ function getCardStateArray(backEndState, perspective=false){
         }
     }
     return card_state;
+}
+
+function properTrumpSuitName(suit) {
+    const suits = {
+        c: 'Clubs',
+        d: 'Diamonds',
+        h: 'Heart',
+        s: 'Spades',
+    };
+    return suits[suit.toLowerCase()];
 }
 
 function getMoveTypes(moves){


### PR DESCRIPTION
Currently while testing, in visual mode, we cannot see what the trump suit is; see the screenshots. This PR adds that piece.
Previously:
![no_suit](https://user-images.githubusercontent.com/20051470/83637232-8ce28b80-a5a7-11ea-845c-ba944d495f5f.png)

Now: 
![with_suit](https://user-images.githubusercontent.com/20051470/83637311-b56a8580-a5a7-11ea-816a-83088c7d94c7.png)
