### PR TITLE
fix: Deterministic tournament results with seed

### DIFF
--- a/api/_deck.py
+++ b/api/_deck.py
@@ -34,7 +34,7 @@ class Deck:
 	# Variable that stores the previous trick that was evaluated.
 	# Starts out as [None, None], then [int, int] after
 	# the first trick has been evaluated.
-	__previous_trick = [None, None];
+	__previous_trick = [None, None]
 
 	# A variable length list of card indexes representing the
 	# cards currently in stock, and more importantly, their order.
@@ -205,7 +205,7 @@ class Deck:
 		self.__card_state[self.__trick[0]] = self.__card_state[self.__trick[1]] = self.__p1_perspective[self.__trick[0]] = self.__p1_perspective[self.__trick[1]] = self.__p2_perspective[self.__trick[0]] = self.__p2_perspective[self.__trick[1]] = "P1W" if winner == 1 else "P2W"
 
 		# Don't need to make a deep copy in this instance, tested.
-		self.__previous_trick = self.__trick;
+		self.__previous_trick = self.__trick
 		self.__trick = [None, None]
 
 	def add_to_perspective(self, player, index, card_state):
@@ -222,14 +222,12 @@ class Deck:
 		else:
 			self.__p2_perspective[index] = card_state
 
-	#Look into overloading this function as well
-	# Generates a new deck based on a seed. If no seed is given, a random seed in generated.
+	# Generates a new deck.
 	@staticmethod
-	def generate(id=None):
+	def generate():
 
-		rng = random.Random(id)
 		shuffled_cards = list(range(20))
-		rng.shuffle(shuffled_cards)
+		random.shuffle(shuffled_cards)
 
 		card_state = [0]*20
 		p1_perspective = ["U"]*20
@@ -257,19 +255,14 @@ class Deck:
 
 		return Deck(card_state, stock, p1_perspective, p2_perspective)
 
-	def make_assumption(self, seed=None):
+	def make_assumption(self):
 		"""
 		Identifies all unknown cards from the perspective of
 		the relevant player, and makes guesses for their states.
 
-		:param seed: Optional random number generator seed.
 		:return: A deck object with the card_state array changed
 		to represent a random guess of the states of the unknown cards.
 		"""
-		if seed is None:
-			seed = random.randint(0, 100000)
-
-		rng = random.Random(seed)
 
 		perspective = self.get_perspective()
 
@@ -277,7 +270,7 @@ class Deck:
 
 		unknowns = [index for index, card in enumerate(perspective) if card == "U"]
 
-		rng.shuffle(unknowns)
+		random.shuffle(unknowns)
 
 		other_player_term = "P2H" if self.__signature == 1 else "P1H"
 

--- a/api/_state.py
+++ b/api/_state.py
@@ -281,25 +281,23 @@ class State:
 		return state
 
 	@staticmethod
-	def generate(id=None, phase=1):
+	def generate(phase=1):
 		"""
-		:param id: The seed used for random generation. Defaults at random, but can be set for deterministic state generation
 		:param phase: The phase at which your generated state starts at
 		:return: A starting state generated using the parameters given
 		"""
 
-		rng = random.Random(id)
-		deck = Deck.generate(id)
-		player1s_turn = rng.choice([True, False])
+		deck = Deck.generate()
+		player1s_turn = random.choice([True, False])
 
 		state = State(deck, player1s_turn)
 
 		if phase == 2:
 			while state.__phase == 1:
 				if state.finished():
-					return State.generate(id if id is None else id+1, phase) # Father forgive me
+					return State.generate(phase)
 
-				state = state.next(rng.choice(state.moves()))
+				state = state.next(random.choice(state.moves()))
 
 			total_score = state.__p1_points + state.__p2_points
 			state.__set_points(1, int(total_score/2))

--- a/api/util.py
+++ b/api/util.py
@@ -17,7 +17,7 @@ def other(
     :param player:
     :return:
     """
-    return 1 if player_id == 2 else 2 # type: int
+    return 1 if player_id == 2 else 2
 
 def get_suit(card_index):
     """

--- a/play.py
+++ b/play.py
@@ -7,12 +7,13 @@ python play.py -h
 """
 
 from argparse import ArgumentParser
-import sys
+import sys, random
 
 from api import State, engine, util
 
-
 def call_engine(options):
+    # Set the seed for the PRNG globally
+    random.seed(options.seed)
 
     # Create player 1
     player1 = util.load_player(options.player1)
@@ -28,7 +29,6 @@ def call_engine(options):
         print('   Start state: ' + str(state))
 
     # Play the game
-
     engine.play(player1, player2, state=state, max_time=options.max_time*1000, verbose=(not options.quiet))
 
 if __name__ == "__main__":
@@ -61,6 +61,10 @@ if __name__ == "__main__":
                         help="Whether to hide the printed output.",
                         action="store_true")
 
+    parser.add_argument("--seed",
+                        dest="seed",
+                        help="Set the initial value for the pseudo-random number generator. Using the same seed will result in the same game outcome if no changes are made.",
+                        default=None)
 
 
     options = parser.parse_args()


### PR DESCRIPTION
For our paper we have to rely on deterministic tournaments so each tournament runs the same games. In this pull request I replaced the pseudo-random number generation (PRNG) behaviour which was local to the functions with a global PRNG seed which can be set in both `tournament.py` as well as `play.py`.

This pull request adds the `--seed` argument to both `tournament.py` as well as `play.py` which accepts a string as input.

Furthermore, using different bots would cause the game states to be different when using the same seed, as the PRNG use by the bot influences the state generation of the tournament in the next loop iteration. Therefore, `tournament.py` now first generates all the states (initial deck) for the games it will run, before calling the engine to have the bots play these states.

To illustrate, when running 10 games in a tournament with the same global seed with the previous behaviour would result in decks: AAAAAAAAAA. 10 identical decks of cards. Now, with the new behaviour the same seed will always result in decks: ABCDEFGHIJ.

To check the new behaviour, try the following commands:
```
python3 tournament.py -p rand,rand -r 10 -f --seed 30
```
When running above command multiple times, the outcome should be the same every time.
When using different bots, the bot behaviour will be different depending on the seed, but the same games are generated. (can manually be checked by printing the state.hand() after line 42 of the `tournament.py` file)


```
python3 play.py -1 rand -2 rand --seed 30
```
When running above command multiple times, the outcome should be the same every time.