### PR TITLE
reduce vagueness of state.get_points()

### DIFF
--- a/api/_state.py
+++ b/api/_state.py
@@ -382,7 +382,12 @@ class State:
 		:param player: The player id of the player whose points we want
 		:return: The points of the requested player
 		"""
-		return self.__p1_points if player == 1 else self.__p2_points
+		if player == 1:
+			return self.__p1_points
+		elif player == 2:
+			return self.__p2_points
+		else:
+			raise ValueError("The player can either be 1 or 2.")
 
 	def get_pending_points(self, player):
 		"""


### PR DESCRIPTION
The get_points() function is ambiguous by accepting any value for player 2 as long as it is not 1. 
This is ambiguous because: 

One would expect that player 0 is player 1 and player 2 is 1
    **or**
player 1 is 1 and player 2 is 2

but by no means that get_points(1) returns the points of player1, while get_points(0) returns the points of player2. However, that is what we found in our code and just caused a short moment of paralyzation. The function is now more explicit and if someone tries to get_points(0) will raise a value error indicating the only players for which points can be returned are 1 and 2.

**Replaced:**
```python
return self.__p1_points if player == 1 else self.__p2_points
```

**With:**
```python
if player == 1:
	return self.__p1_points
elif player == 2:
	return self.__p2_points
else:
	raise ValueError("The player can either be 1 or 2.")
```